### PR TITLE
Fix address line delimiter

### DIFF
--- a/swissqr/index.php
+++ b/swissqr/index.php
@@ -9,7 +9,7 @@ $QR_VERSION = 10;
 $QR_SIZE = 19;
 $QR_MARGIN = 0;
 $QR_ERRCORR = 'M';
-$LINEDELIM = 'br /';
+$LINEDELIM = '<br />';
 
 #### ==== VARS ==== ####
 
@@ -413,7 +413,7 @@ else {
 	}
 	else {	
 		if(!empty($LINEDELIM)) {
-			$CRAddressLines = explode("br /", $CRAddress_raw);
+			$CRAddressLines = explode($LINEDELIM, $CRAddress_raw);
 			$CRAddressLine1 = substr($CRAddressLines[0], 0, 70);
 			$CRAddressLine2 = substr($CRAddressLines[1], 0, 70);
 			$QRCONTENT["CRAddressline1"] = $CRAddressLine1;


### PR DESCRIPTION
The current line delimiter is incorrect, which causes issues at the Post office. They will not be able to correctly validate the QR since the address fields of the company and customer contain invalid characters.

A validation shows the address like this:

```
Street 12<
>3000 Bern
```

I consider this PR to just be a quick and dirty fix. The HTML line break tag used by Twig ("\<br />") might change anytime, breaking this in the future. A proper fix should account for all variations of the line break tag.